### PR TITLE
fix: use existing secret names for backup job

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -723,11 +723,13 @@ jobs:
 
       - name: Create config
         run: |
-          cat > supamigrate.toml << 'EOF'
+          # Extract project_ref from PROD_DB_URL (format: db.PROJECT_REF.supabase.co)
+          PROJECT_REF=$(echo "${{ secrets.PROD_DB_URL }}" | sed 's/db\.\(.*\)\.supabase\.co/\1/')
+          cat > supamigrate.toml << EOF
           [projects.production]
-          project_ref = "${{ secrets.SUPABASE_PROJECT_REF }}"
-          db_password = "${{ secrets.SUPABASE_DB_PASSWORD }}"
-          service_key = "${{ secrets.SUPABASE_SERVICE_KEY }}"
+          project_ref = "${PROJECT_REF}"
+          db_password = "${{ secrets.PROD_DB_PASS }}"
+          service_key = "${{ secrets.SUPABASE_SERVICE_ROLE }}"
 
           [defaults]
           compress_backups = true


### PR DESCRIPTION
## Summary
- Maps backup job to use existing GitHub secrets
- Extracts project_ref from PROD_DB_URL
- Uses PROD_DB_PASS and SUPABASE_SERVICE_ROLE

## Test plan
- [ ] Trigger workflow_dispatch after merge
- [ ] Verify backup job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration for improved configuration management.

---

**Note:** This release contains infrastructure updates with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->