### PR TITLE
fix: use MINIO_BUCKET secret

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -749,9 +749,8 @@ jobs:
           ./mc alias set backup ${{ secrets.MINIO_ENDPOINT }} \
             ${{ secrets.MINIO_ACCESS_KEY }} \
             ${{ secrets.MINIO_SECRET_KEY }}
-          ./mc mb --ignore-existing backup/supabase-backups
           DATE=$(date +%Y-%m-%d)
-          ./mc cp --recursive backup/ backup/supabase-backups/${DATE}/
+          ./mc cp --recursive backup/ backup/${{ secrets.MINIO_BUCKET }}/${DATE}/
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
Use MINIO_BUCKET secret for bucket name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backup workflow storage configuration to use dynamic path structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->