### PR TITLE
fix: correct backup CLI syntax

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -738,7 +738,7 @@ jobs:
       - name: Run backup
         run: |
           mkdir -p backup
-          ./target/release/supamigrate backup production --output backup/
+          ./target/release/supamigrate backup --project production --output backup/
         env:
           RUST_LOG: info
 


### PR DESCRIPTION
Use --project flag for backup command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backup workflow configuration to use explicit named parameters for improved command syntax clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->