### PR TITLE
feat: switch from MinIO to Cloudflare R2 storage

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -730,16 +730,16 @@ jobs:
         env:
           RUST_LOG: info
 
-      - name: Upload to MinIO S3
+      - name: Upload to Cloudflare R2
         run: |
           curl -sO https://dl.min.io/client/mc/release/linux-amd64/mc
           chmod +x mc
-          ./mc alias set minio ${{ secrets.MINIO_ENDPOINT }} \
-            ${{ secrets.MINIO_ACCESS_KEY }} \
-            ${{ secrets.MINIO_SECRET_KEY }}
+          ./mc alias set r2 ${{ secrets.R2_ENDPOINT }} \
+            ${{ secrets.R2_ACCESS_KEY }} \
+            ${{ secrets.R2_SECRET_KEY }}
           # Upload with date folder
           DATE=$(date +%Y-%m-%d)
-          ./mc cp dumps/*.dump minio/${{ secrets.MINIO_BUCKET }}/${DATE}/
+          ./mc cp dumps/*.dump r2/${{ secrets.R2_BUCKET }}/${DATE}/
           # Verify upload
-          ./mc ls minio/${{ secrets.MINIO_BUCKET }}/${DATE}/
+          ./mc ls r2/${{ secrets.R2_BUCKET }}/${DATE}/
 


### PR DESCRIPTION
Switches backup storage from self-hosted MinIO to Cloudflare R2 (10GB free tier, no egress fees).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment pipeline to use Cloudflare R2 for backup and staging operations, replacing the previous object storage configuration with updated credentials and endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->