### PR TITLE
feat: add 30-day retention policy for R2 backups

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -740,6 +740,8 @@ jobs:
           # Upload with date folder
           DATE=$(date +%Y-%m-%d)
           ./mc cp dumps/*.dump r2/${{ secrets.R2_BUCKET }}/${DATE}/
-          # Verify upload
-          ./mc ls r2/${{ secrets.R2_BUCKET }}/${DATE}/
+          # Cleanup: remove backups older than 30 days (keeps ~360MB of 1GB limit)
+          ./mc rm --recursive --force --older-than 30d r2/${{ secrets.R2_BUCKET }}/ || true
+          # Show remaining backups
+          ./mc ls r2/${{ secrets.R2_BUCKET }}/
 


### PR DESCRIPTION
Auto-deletes backups older than 30 days to keep storage under 1GB (10% of R2 free tier).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backup maintenance workflow to automatically remove backups older than 30 days, optimizing storage usage and reducing operational overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->