### PR TITLE
fix: enforce global workflow concurrency (one run at a time)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -50,7 +50,7 @@ env:
   RUST_LOG: info
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary
- Remove `github.ref` from concurrency group so all Pipeline runs share the same group
- Any new run now cancels ALL in-progress runs regardless of branch or event type
- Ensures only one workflow instance runs at a time globally

## Test plan
- [ ] Push a commit and verify any existing runs are cancelled
- [ ] Open a PR and verify it cancels any running workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration for improved build process efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->