### PR TITLE
refactor: split backup into 5 granular sequential jobs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -704,20 +704,19 @@ jobs:
           retention-days: 90
 
   # ---------------------------------------------------------------------------
-  # Backup Jobs (Sequential: Database -> Edge Functions -> Upload)
+  # Backup Jobs (Sequential Pipeline)
+  # Order: Database -> RLS Policies -> Triggers -> Edge Functions -> Upload
   # ---------------------------------------------------------------------------
 
-  # Job 1: Database Backup (includes schema, data, RLS policies, triggers, functions)
+  # Job 1: Full Database Dump
   backup-database:
-    name: Backup Database
+    name: 1. Database Dump
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     outputs:
       timestamp: ${{ steps.dump.outputs.timestamp }}
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Dump PostgreSQL database
         id: dump
         run: |
@@ -725,7 +724,7 @@ jobs:
           TIMESTAMP=$(date +%Y%m%d_%H%M%S)
           echo "timestamp=$TIMESTAMP" >> $GITHUB_OUTPUT
 
-          echo "📦 Starting database backup..."
+          echo "📦 Dumping full database..."
           PGPASSWORD="${{ secrets.SUPABASE_DB_PASS }}" pg_dump \
             -h "${{ secrets.SUPABASE_POOLER_HOST }}" \
             -p 5432 \
@@ -735,24 +734,149 @@ jobs:
             -Fc -f dumps/database_${TIMESTAMP}.dump
 
           echo "✅ Database dump complete"
-          ls -la dumps/
+          ls -lh dumps/
 
-      - name: Upload database artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: backup-database
           path: dumps/*.dump
           retention-days: 1
 
-  # Job 2: Edge Functions Backup
-  backup-edge-functions:
-    name: Backup Edge Functions
+  # Job 2: Extract RLS Policies
+  backup-rls-policies:
+    name: 2. RLS Policies
     runs-on: ubuntu-latest
     needs: backup-database
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Extract RLS policies
+        run: |
+          mkdir -p dumps
+          TIMESTAMP="${{ needs.backup-database.outputs.timestamp }}"
 
+          echo "📦 Extracting RLS policies..."
+          PGPASSWORD="${{ secrets.SUPABASE_DB_PASS }}" psql \
+            -h "${{ secrets.SUPABASE_POOLER_HOST }}" \
+            -p 5432 \
+            -U "${{ secrets.SUPABASE_DB_USER }}" \
+            -d postgres \
+            -c "
+              SELECT '-- RLS Policies Export' AS header;
+              SELECT format(
+                'CREATE POLICY %I ON %I.%I FOR %s TO %s %s %s;',
+                pol.polname,
+                n.nspname,
+                c.relname,
+                CASE pol.polcmd
+                  WHEN 'r' THEN 'SELECT'
+                  WHEN 'a' THEN 'INSERT'
+                  WHEN 'w' THEN 'UPDATE'
+                  WHEN 'd' THEN 'DELETE'
+                  WHEN '*' THEN 'ALL'
+                END,
+                CASE WHEN pol.polroles = '{0}' THEN 'public'
+                     ELSE array_to_string(ARRAY(SELECT rolname FROM pg_roles WHERE oid = ANY(pol.polroles)), ', ')
+                END,
+                CASE WHEN pol.polqual IS NOT NULL THEN 'USING (' || pg_get_expr(pol.polqual, pol.polrelid) || ')' ELSE '' END,
+                CASE WHEN pol.polwithcheck IS NOT NULL THEN 'WITH CHECK (' || pg_get_expr(pol.polwithcheck, pol.polrelid) || ')' ELSE '' END
+              )
+              FROM pg_policy pol
+              JOIN pg_class c ON c.oid = pol.polrelid
+              JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+              ORDER BY n.nspname, c.relname, pol.polname;
+            " -t -A > dumps/rls_policies_${TIMESTAMP}.sql
+
+          POLICY_COUNT=$(grep -c "CREATE POLICY" dumps/rls_policies_${TIMESTAMP}.sql 2>/dev/null || echo "0")
+          echo "✅ Extracted $POLICY_COUNT RLS policies"
+          ls -lh dumps/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backup-rls
+          path: dumps/*.sql
+          retention-days: 1
+
+  # Job 3: Extract Trigger Functions
+  backup-triggers:
+    name: 3. Triggers & Functions
+    runs-on: ubuntu-latest
+    needs: backup-rls-policies
+
+    steps:
+      - name: Extract triggers and functions
+        run: |
+          mkdir -p dumps
+          TIMESTAMP="${{ needs.backup-database.outputs.timestamp }}"
+
+          echo "📦 Extracting triggers..."
+          PGPASSWORD="${{ secrets.SUPABASE_DB_PASS }}" psql \
+            -h "${{ secrets.SUPABASE_POOLER_HOST }}" \
+            -p 5432 \
+            -U "${{ secrets.SUPABASE_DB_USER }}" \
+            -d postgres \
+            -c "
+              SELECT '-- Triggers Export' AS header;
+              SELECT format(
+                'CREATE TRIGGER %I %s %s ON %I.%I FOR EACH %s EXECUTE FUNCTION %s;',
+                t.tgname,
+                CASE WHEN t.tgtype & 2 = 2 THEN 'BEFORE' ELSE 'AFTER' END,
+                array_to_string(ARRAY[
+                  CASE WHEN t.tgtype & 4 = 4 THEN 'INSERT' END,
+                  CASE WHEN t.tgtype & 8 = 8 THEN 'DELETE' END,
+                  CASE WHEN t.tgtype & 16 = 16 THEN 'UPDATE' END
+                ]::text[], ' OR '),
+                n.nspname,
+                c.relname,
+                CASE WHEN t.tgtype & 1 = 1 THEN 'ROW' ELSE 'STATEMENT' END,
+                p.proname || '()'
+              )
+              FROM pg_trigger t
+              JOIN pg_class c ON c.oid = t.tgrelid
+              JOIN pg_namespace n ON n.oid = c.relnamespace
+              JOIN pg_proc p ON p.oid = t.tgfoid
+              WHERE NOT t.tgisinternal
+                AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+              ORDER BY n.nspname, c.relname, t.tgname;
+            " -t -A > dumps/triggers_${TIMESTAMP}.sql
+
+          echo "📦 Extracting user-defined functions..."
+          PGPASSWORD="${{ secrets.SUPABASE_DB_PASS }}" psql \
+            -h "${{ secrets.SUPABASE_POOLER_HOST }}" \
+            -p 5432 \
+            -U "${{ secrets.SUPABASE_DB_USER }}" \
+            -d postgres \
+            -c "
+              SELECT '-- Functions Export' AS header;
+              SELECT pg_get_functiondef(p.oid) || ';'
+              FROM pg_proc p
+              JOIN pg_namespace n ON n.oid = p.pronamespace
+              WHERE n.nspname NOT IN ('pg_catalog', 'information_schema', 'extensions')
+                AND p.prokind = 'f'
+              ORDER BY n.nspname, p.proname;
+            " -t -A > dumps/functions_${TIMESTAMP}.sql
+
+          TRIGGER_COUNT=$(grep -c "CREATE TRIGGER" dumps/triggers_${TIMESTAMP}.sql 2>/dev/null || echo "0")
+          FUNC_COUNT=$(grep -c "CREATE.*FUNCTION" dumps/functions_${TIMESTAMP}.sql 2>/dev/null || echo "0")
+          echo "✅ Extracted $TRIGGER_COUNT triggers, $FUNC_COUNT functions"
+          ls -lh dumps/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backup-triggers
+          path: dumps/*.sql
+          retention-days: 1
+
+  # Job 4: Edge Functions (Supabase)
+  backup-edge-functions:
+    name: 4. Edge Functions
+    runs-on: ubuntu-latest
+    needs: backup-triggers
+
+    steps:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -763,10 +887,11 @@ jobs:
 
       - name: Download edge functions
         run: |
-          PROJECT_REF=$(echo "${{ secrets.SUPABASE_URL }}" | sed -n 's|https://\([^.]*\)\.supabase\.co.*|\1|p')
-          echo "📦 Backing up edge functions for project: $PROJECT_REF"
-
           mkdir -p dumps/functions
+          PROJECT_REF=$(echo "${{ secrets.SUPABASE_URL }}" | sed -n 's|https://\([^.]*\)\.supabase\.co.*|\1|p')
+          TIMESTAMP="${{ needs.backup-database.outputs.timestamp }}"
+
+          echo "📦 Backing up edge functions for: $PROJECT_REF"
 
           FUNCTIONS=$(supabase functions list --project-ref "$PROJECT_REF" 2>/dev/null | tail -n +2 | awk '{print $1}' | grep -v '^$' || true)
 
@@ -776,49 +901,44 @@ jobs:
               supabase functions download "$FUNC_NAME" --project-ref "$PROJECT_REF" || true
             done
             mv supabase/functions/* dumps/functions/ 2>/dev/null || true
-          fi
-
-          TIMESTAMP="${{ needs.backup-database.outputs.timestamp }}"
-          if [ -d "dumps/functions" ] && [ "$(ls -A dumps/functions 2>/dev/null)" ]; then
-            tar -czf "dumps/functions_${TIMESTAMP}.tar.gz" -C dumps/functions .
-            echo "✅ Edge functions backup complete"
+            tar -czf "dumps/edge_functions_${TIMESTAMP}.tar.gz" -C dumps/functions .
+            EDGE_COUNT=$(echo "$FUNCTIONS" | wc -l | tr -d ' ')
+            echo "✅ Backed up $EDGE_COUNT edge functions"
           else
             echo "⚠️ No edge functions found"
-            touch "dumps/functions_${TIMESTAMP}.tar.gz"
+            touch "dumps/edge_functions_${TIMESTAMP}.tar.gz"
           fi
-          ls -la dumps/
+          rm -rf dumps/functions supabase/
+          ls -lh dumps/
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
-      - name: Upload functions artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: backup-functions
+          name: backup-edge-functions
           path: dumps/*.tar.gz
           retention-days: 1
 
-  # Job 3: Upload all backups to R2
+  # Job 5: Upload all to R2
   backup-upload:
-    name: Upload to R2
+    name: 5. Upload to R2
     runs-on: ubuntu-latest
-    needs: [backup-database, backup-edge-functions]
+    needs: [backup-database, backup-rls-policies, backup-triggers, backup-edge-functions]
 
     steps:
-      - name: Download database backup
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          name: backup-database
           path: dumps/
-
-      - name: Download functions backup
-        uses: actions/download-artifact@v4
-        with:
-          name: backup-functions
-          path: dumps/
+          pattern: backup-*
+          merge-multiple: true
 
       - name: Upload to Cloudflare R2
         run: |
-          echo "📤 Uploading backups to R2..."
+          echo "📤 Uploading all backups to R2..."
+          ls -lh dumps/
+
           curl -sO https://dl.min.io/client/mc/release/linux-amd64/mc
           chmod +x mc
           ./mc alias set r2 ${{ secrets.R2_ENDPOINT }} \
@@ -826,8 +946,7 @@ jobs:
             ${{ secrets.R2_SECRET_KEY }}
 
           DATE=$(date +%Y-%m-%d)
-          ./mc cp dumps/*.dump r2/${{ secrets.R2_BUCKET }}/${DATE}/
-          ./mc cp dumps/*.tar.gz r2/${{ secrets.R2_BUCKET }}/${DATE}/ || true
+          ./mc cp dumps/* r2/${{ secrets.R2_BUCKET }}/${DATE}/
 
           # Cleanup: remove backups older than 30 days
           ./mc rm --recursive --force --older-than 30d r2/${{ secrets.R2_BUCKET }}/ || true


### PR DESCRIPTION
## Summary
Split backup into 5 separate sequential jobs for better visibility and debugging.

## Jobs (run in order)
| # | Job | Output |
|---|-----|--------|
| 1 | **Database Dump** | `database_TIMESTAMP.dump` |
| 2 | **RLS Policies** | `rls_policies_TIMESTAMP.sql` |
| 3 | **Triggers & Functions** | `triggers_TIMESTAMP.sql`, `functions_TIMESTAMP.sql` |
| 4 | **Edge Functions** | `edge_functions_TIMESTAMP.tar.gz` |
| 5 | **Upload to R2** | All artifacts uploaded |

## Changes
- Storage backup **removed** (was taking 20+ min)
- Each component now has its own job
- Jobs run sequentially via `needs:` dependencies
- Clear progress visibility in Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)