### PR TITLE
chore: add work/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ supamigrate.toml
 # Test artifacts
 *.sql
 *.sql.gz
+
+# Work/temp directories
+work/


### PR DESCRIPTION
## Summary
Add `work/` directory to .gitignore to prevent accidental commit of temporary files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)