### PR TITLE
docs: add R2 storage example to config

### DIFF
--- a/supamigrate.example.toml
+++ b/supamigrate.example.toml
@@ -15,3 +15,12 @@ service_key = "staging-service-key"
 [defaults]
 parallel_transfers = 4    # Concurrent file uploads/downloads
 compress_backups = true   # Gzip database dumps
+
+# Optional: Cloud storage for backups (S3-compatible)
+# Used by CI/CD pipeline for remote backup storage
+[storage.r2]
+endpoint = "https://your-account-id.r2.cloudflarestorage.com"
+bucket = "supabase-backups"
+access_key = "your-r2-access-key"
+secret_key = "your-r2-secret-key"
+region = "auto"


### PR DESCRIPTION
Shows users how to configure S3-compatible storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added S3-compatible backup storage configuration options with support for endpoint, bucket credentials, and region settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->