### PR TITLE
docs: add access_token to config example

### DIFF
--- a/supamigrate.example.toml
+++ b/supamigrate.example.toml
@@ -6,11 +6,13 @@
 project_ref = "your-project-ref"          # From Supabase dashboard URL
 db_password = "your-database-password"    # Database password
 service_key = "your-service-role-key"     # Service role JWT (not anon key)
+access_token = "sbp_xxxxxxxxxxxxx"        # Personal access token (for edge functions)
 
 [projects.staging]
 project_ref = "your-staging-ref"
 db_password = "staging-password"
 service_key = "staging-service-key"
+access_token = "sbp_xxxxxxxxxxxxx"
 
 [defaults]
 parallel_transfers = 4    # Concurrent file uploads/downloads


### PR DESCRIPTION
Required for edge functions backup.